### PR TITLE
Fix the Inconsistency in cf files command

### DIFF
--- a/cf/commands/application/files.go
+++ b/cf/commands/application/files.go
@@ -31,7 +31,7 @@ func (cmd *Files) Metadata() command_metadata.CommandMetadata {
 		Name:        "files",
 		ShortName:   "f",
 		Description: T("Print out a list of files in a directory or the contents of a specific file"),
-		Usage:       T("CF_NAME files APP [-i INSTANCE] [PATH]"),
+		Usage:       T("CF_NAME files APP PATH [-i INSTANCE]"),
 		Flags: []cli.Flag{
 			flag_helpers.NewIntFlag("i", T("Instance")),
 		},
@@ -39,7 +39,7 @@ func (cmd *Files) Metadata() command_metadata.CommandMetadata {
 }
 
 func (cmd *Files) GetRequirements(requirementsFactory requirements.Factory, c *cli.Context) (reqs []requirements.Requirement, err error) {
-	if len(c.Args()) < 1 {
+	if len(c.Args()) != 2 {
 		cmd.ui.FailWithUsage(c)
 	}
 
@@ -81,10 +81,7 @@ func (cmd *Files) Run(c *cli.Context) {
 			"SpaceName": terminal.EntityNameColor(cmd.config.SpaceFields().Name),
 			"Username":  terminal.EntityNameColor(cmd.config.Username())}))
 
-	path := "/"
-	if len(c.Args()) > 1 {
-		path = c.Args()[1]
-	}
+	path := c.Args()[1]
 
 	list, apiErr := cmd.appFilesRepo.ListFiles(app.Guid, instance, path)
 	if apiErr != nil {

--- a/cf/commands/application/files_test.go
+++ b/cf/commands/application/files_test.go
@@ -46,7 +46,7 @@ var _ = Describe("files command", func() {
 			Expect(testcmd.CommandDidPassRequirements).To(BeFalse())
 		})
 
-		It("fails with usage when not provided an app name", func() {
+		It("fails with usage when not provided exact num of args", func() {
 			requirementsFactory.LoginSuccess = true
 			requirementsFactory.TargetedSpaceSuccess = true
 			runCommand()
@@ -56,7 +56,7 @@ var _ = Describe("files command", func() {
 		})
 	})
 
-	Context("when logged in, a space is targeted and a valid app name is provided", func() {
+	Context("when logged in, a space is targeted and a valid app name and path are provided", func() {
 		BeforeEach(func() {
 			app := models.Application{}
 			app.Name = "my-found-app"
@@ -92,7 +92,7 @@ var _ = Describe("files command", func() {
 
 		Context("checking for bad flags", func() {
 			It("fails when non-positive value is given for instance", func() {
-				runCommand("-i", "-1", "my-app")
+				runCommand("-i", "-1", "my-app", "/foo")
 
 				Expect(ui.Outputs).To(ContainSubstrings(
 					[]string{"FAILED"},
@@ -102,7 +102,7 @@ var _ = Describe("files command", func() {
 			})
 
 			It("fails when instance is larger than instance count", func() {
-				runCommand("-i", "5", "my-app")
+				runCommand("-i", "5", "my-app", "/foo")
 
 				Expect(ui.Outputs).To(ContainSubstrings(
 					[]string{"FAILED"},

--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -700,8 +700,8 @@
       "modified": false
    },
    {
-      "id": "CF_NAME files APP [-i INSTANCE] [PATH]",
-      "translation": "CF_NAME files APP [PATH]",
+      "id": "CF_NAME files APP PATH [-i INSTANCE]",
+      "translation": "CF_NAME files APP PATH [-i INSTANCE]",
       "modified": true
    },
    {

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -700,8 +700,8 @@
       "modified": false
    },
    {
-      "id": "CF_NAME files APP [-i INSTANCE] [PATH]",
-      "translation": "CF_NAME files APP [-i INSTANCE] [PATH]",
+      "id": "CF_NAME files APP PATH [-i INSTANCE]",
+      "translation": "CF_NAME files APP PATH [-i INSTANCE]",
       "modified": false
    },
    {

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -700,8 +700,8 @@
       "modified": false
    },
    {
-      "id": "CF_NAME files APP [-i INSTANCE] [PATH]",
-      "translation": "CF_NAME files APP [PATH]",
+      "id": "CF_NAME files APP PATH [-i INSTANCE]",
+      "translation": "CF_NAME files APP PATH [-i INSTANCE]",
       "modified": true
    },
    {

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -700,8 +700,8 @@
       "modified": false
    },
    {
-      "id": "CF_NAME files APP [-i INSTANCE] [PATH]",
-      "translation": "CF_NAME files APP [PATH]",
+      "id": "CF_NAME files APP PATH [-i INSTANCE]",
+      "translation": "CF_NAME files APP PATH [-i INSTANCE]",
       "modified": true
    },
    {

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -700,8 +700,8 @@
       "modified": false
    },
    {
-      "id": "CF_NAME files APP [-i INSTANCE] [PATH]",
-      "translation": "CF_NAME files APP [PATH]",
+      "id": "CF_NAME files APP PATH [-i INSTANCE]",
+      "translation": "CF_NAME files APP PATH [-i INSTANCE]",
       "modified": true
    },
    {

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -700,8 +700,8 @@
       "modified": false
    },
    {
-      "id": "CF_NAME files APP [-i INSTANCE] [PATH]",
-      "translation": "CF_NAME files APP [PATH]",
+      "id": "CF_NAME files APP PATH [-i INSTANCE]",
+      "translation": "CF_NAME files APP PATH [-i INSTANCE]",
       "modified": true
    },
    {

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -700,8 +700,8 @@
       "modified": false
    },
    {
-      "id": "CF_NAME files APP [-i INSTANCE] [PATH]",
-      "translation": "CF_NAME files APP [-i INSTÂNCIA] [CAMINHO]",
+      "id": "CF_NAME files APP PATH [-i INSTANCE]",
+      "translation": "CF_NAME files APP CAMINHO [-i INSTÂNCIA]",
       "modified": true
    },
    {

--- a/cf/i18n/resources/zh_Hans.all.json
+++ b/cf/i18n/resources/zh_Hans.all.json
@@ -700,8 +700,8 @@
       "modified": false
    },
    {
-      "id": "CF_NAME files APP [-i INSTANCE] [PATH]",
-      "translation": "CF_NAME files 应用程序名 [路径]",
+      "id": "CF_NAME files APP PATH [-i INSTANCE]",
+      "translation": "CF_NAME files 路径 应用程序名",
       "modified": true
    },
    {

--- a/cf/i18n/resources/zh_Hant.all.json
+++ b/cf/i18n/resources/zh_Hant.all.json
@@ -700,8 +700,8 @@
       "modified": false
    },
    {
-      "id": "CF_NAME files APP [-i INSTANCE] [PATH]",
-      "translation": "CF_NAME files APP [PATH]",
+      "id": "CF_NAME files APP PATH [-i INSTANCE]",
+      "translation": "CF_NAME files APP PATH [-i INSTANCE]",
       "modified": true
    },
    {


### PR DESCRIPTION
Before Fix: If cf user does
'cf files my-app' or 'cf files my-app path'
then its success but path is niehter optional not required

After Fix:If cf user does
'cf files my-app path'
then it will succ  but 'cf files my-app' will fail
so path is now reqired parameter

http://rnd-github.huawei.com/paas/cli/issues/12#issuecomment-5478
