### PR TITLE
Fix the Usage info in cf security-groups command

### DIFF
--- a/cf/commands/securitygroup/security_groups.go
+++ b/cf/commands/securitygroup/security_groups.go
@@ -31,7 +31,7 @@ func (cmd SecurityGroups) Metadata() command_metadata.CommandMetadata {
 	return command_metadata.CommandMetadata{
 		Name:        "security-groups",
 		Description: T("List all security groups"),
-		Usage:       "CF_NAME security-group",
+		Usage:       "CF_NAME security-groups",
 	}
 }
 


### PR DESCRIPTION
Before Fix: If cf user does
'cf security-groups blahblah'
the usage is
USAGE:
   cf security-group

After Fix:If cf user does
'cf security-groups blahblah'
the usage is
USAGE:
   cf security-groups

http://rnd-github.huawei.com/paas/cli/issues/20
