### PR TITLE
Fix the usage info in cf feature-flag command

### DIFF
--- a/cf/commands/featureflag/feature_flag.go
+++ b/cf/commands/featureflag/feature_flag.go
@@ -31,7 +31,7 @@ func (cmd ShowFeatureFlag) Metadata() command_metadata.CommandMetadata {
 	return command_metadata.CommandMetadata{
 		Name:        "feature-flag",
 		Description: T("Retrieve an individual feature flag with status"),
-		Usage:       T("CF_NAME feature-flag"),
+		Usage:       T("CF_NAME feature-flag FEATURE_NAME"),
 	}
 }
 

--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -690,8 +690,8 @@
       "modified": false
    },
    {
-      "id": "CF_NAME feature-flag",
-      "translation": "CF_NAME feature-flag",
+      "id": "CF_NAME feature-flag FEATURE_NAME",
+      "translation": "CF_NAME feature-flag FEATURE_NAME",
       "modified": false
    },
    {

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -690,8 +690,8 @@
       "modified": false
    },
    {
-      "id": "CF_NAME feature-flag",
-      "translation": "CF_NAME feature-flag",
+      "id": "CF_NAME feature-flag FEATURE_NAME",
+      "translation": "CF_NAME feature-flag FEATURE_NAME",
       "modified": false
    },
    {

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -690,8 +690,8 @@
       "modified": false
    },
    {
-      "id": "CF_NAME feature-flag",
-      "translation": "CF_NAME feature-flag",
+      "id": "CF_NAME feature-flag FEATURE_NAME",
+      "translation": "CF_NAME feature-flag FEATURE_NAME",
       "modified": false
    },
    {

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -690,8 +690,8 @@
       "modified": false
    },
    {
-      "id": "CF_NAME feature-flag",
-      "translation": "CF_NAME feature-flag",
+      "id": "CF_NAME feature-flag FEATURE_NAME",
+      "translation": "CF_NAME feature-flag FEATURE_NAME",
       "modified": false
    },
    {

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -690,8 +690,8 @@
       "modified": false
    },
    {
-      "id": "CF_NAME feature-flag",
-      "translation": "CF_NAME feature-flag",
+      "id": "CF_NAME feature-flag FEATURE_NAME",
+      "translation": "CF_NAME feature-flag FEATURE_NAME",
       "modified": false
    },
    {

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -690,8 +690,8 @@
       "modified": false
    },
    {
-      "id": "CF_NAME feature-flag",
-      "translation": "CF_NAME feature-flag",
+      "id": "CF_NAME feature-flag FEATURE_NAME",
+      "translation": "CF_NAME feature-flag FEATURE_NAME",
       "modified": false
    },
    {

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -690,8 +690,8 @@
       "modified": false
    },
    {
-      "id": "CF_NAME feature-flag",
-      "translation": "CF_NAME feature-flag",
+      "id": "CF_NAME feature-flag FEATURE_NAME",
+      "translation": "CF_NAME feature-flag FEATURE_NAME",
       "modified": false
    },
    {

--- a/cf/i18n/resources/zh_Hans.all.json
+++ b/cf/i18n/resources/zh_Hans.all.json
@@ -690,8 +690,8 @@
       "modified": false
    },
    {
-      "id": "CF_NAME feature-flag",
-      "translation": "CF_NAME feature-flag",
+      "id": "CF_NAME feature-flag FEATURE_NAME",
+      "translation": "CF_NAME feature-flag FEATURE_NAME",
       "modified": false
    },
    {

--- a/cf/i18n/resources/zh_Hant.all.json
+++ b/cf/i18n/resources/zh_Hant.all.json
@@ -690,8 +690,8 @@
       "modified": false
    },
    {
-      "id": "CF_NAME feature-flag",
-      "translation": "CF_NAME feature-flag",
+      "id": "CF_NAME feature-flag FEATURE_NAME",
+      "translation": "CF_NAME feature-flag FEATURE_NAME",
       "modified": false
    },
    {


### PR DESCRIPTION
Before Fix: If cf user does
'cf feature-flag'
the usage is
USAGE:
   cf feature-flag

After Fix:If cf user does
'cf feature-flag'
the usage is
USAGE:
   cf feature-flag FEATURE_NAME

http://rnd-github.huawei.com/paas/cli/issues/21
