### PR TITLE
Fix the args validation in below commands

### DIFF
--- a/cf/commands/application/app.go
+++ b/cf/commands/application/app.go
@@ -49,7 +49,7 @@ func (cmd *ShowApp) Metadata() command_metadata.CommandMetadata {
 }
 
 func (cmd *ShowApp) GetRequirements(requirementsFactory requirements.Factory, c *cli.Context) (reqs []requirements.Requirement, err error) {
-	if len(c.Args()) < 1 {
+	if len(c.Args()) != 1 {
 		cmd.ui.FailWithUsage(c)
 	}
 

--- a/cf/commands/application/app_test.go
+++ b/cf/commands/application/app_test.go
@@ -57,7 +57,7 @@ var _ = Describe("app Command", func() {
 			Expect(runCommand("cf-plays-dwarf-fortress")).To(BeFalse())
 		})
 
-		It("fails with usage when no arguments are given", func() {
+		It("fails with usage when not provided exactly one arg", func() {
 			passed := runCommand()
 			Expect(ui.FailedWithUsage).To(BeTrue())
 			Expect(passed).To(BeFalse())

--- a/cf/commands/application/apps.go
+++ b/cf/commands/application/apps.go
@@ -37,6 +37,9 @@ func (cmd ListApps) Metadata() command_metadata.CommandMetadata {
 }
 
 func (cmd ListApps) GetRequirements(requirementsFactory requirements.Factory, c *cli.Context) (reqs []requirements.Requirement, err error) {
+	if len(c.Args()) != 0 {
+		cmd.ui.FailWithUsage(c)
+	}
 	reqs = []requirements.Requirement{
 		requirementsFactory.NewLoginRequirement(),
 		requirementsFactory.NewTargetedSpaceRequirement(),

--- a/cf/commands/application/apps_test.go
+++ b/cf/commands/application/apps_test.go
@@ -33,9 +33,9 @@ var _ = Describe("list-apps command", func() {
 		}
 	})
 
-	runCommand := func() bool {
+	runCommand := func(args ...string) bool {
 		cmd := NewListApps(ui, configRepo, appSummaryRepo)
-		return testcmd.RunCommand(cmd, []string{}, requirementsFactory)
+		return testcmd.RunCommand(cmd, args, requirementsFactory)
 	}
 
 	Describe("requirements", func() {
@@ -49,6 +49,12 @@ var _ = Describe("list-apps command", func() {
 			requirementsFactory.TargetedSpaceSuccess = false
 
 			Expect(runCommand()).To(BeFalse())
+		})
+		It("should fail with usage when provided any arguments", func() {
+			requirementsFactory.LoginSuccess = true
+			requirementsFactory.TargetedSpaceSuccess = true
+			Expect(runCommand("blahblah")).To(BeFalse())
+			Expect(ui.FailedWithUsage).To(BeTrue())
 		})
 	})
 

--- a/cf/commands/application/delete.go
+++ b/cf/commands/application/delete.go
@@ -43,7 +43,7 @@ func (cmd *DeleteApp) Metadata() command_metadata.CommandMetadata {
 }
 
 func (cmd *DeleteApp) GetRequirements(requirementsFactory requirements.Factory, c *cli.Context) (reqs []requirements.Requirement, err error) {
-	if len(c.Args()) == 0 {
+	if len(c.Args()) != 1 {
 		cmd.ui.FailWithUsage(c)
 	}
 

--- a/cf/commands/application/delete_test.go
+++ b/cf/commands/application/delete_test.go
@@ -56,7 +56,7 @@ var _ = Describe("delete app command", func() {
 			requirementsFactory.LoginSuccess = true
 		})
 
-		It("provides the user usage text when no app name is given", func() {
+		It("fails with usage when not provided exactly one arg", func() {
 			runCommand()
 			Expect(ui.FailedWithUsage).To(BeTrue())
 		})

--- a/cf/commands/application/restart.go
+++ b/cf/commands/application/restart.go
@@ -41,7 +41,7 @@ func (cmd *Restart) Metadata() command_metadata.CommandMetadata {
 }
 
 func (cmd *Restart) GetRequirements(requirementsFactory requirements.Factory, c *cli.Context) (reqs []requirements.Requirement, err error) {
-	if len(c.Args()) == 0 {
+	if len(c.Args()) != 1 {
 		cmd.ui.FailWithUsage(c)
 	}
 

--- a/cf/commands/application/restart_test.go
+++ b/cf/commands/application/restart_test.go
@@ -40,7 +40,7 @@ var _ = Describe("restart command", func() {
 	}
 
 	Describe("requirements", func() {
-		It("fails with usage when an app name is not given", func() {
+		It("fails with usage when not provided exactly one arg", func() {
 			requirementsFactory.LoginSuccess = true
 			runCommand()
 			Expect(ui.FailedWithUsage).To(BeTrue())

--- a/cf/commands/application/start.go
+++ b/cf/commands/application/start.go
@@ -101,7 +101,7 @@ func (cmd *Start) Metadata() command_metadata.CommandMetadata {
 }
 
 func (cmd *Start) GetRequirements(requirementsFactory requirements.Factory, c *cli.Context) (reqs []requirements.Requirement, err error) {
-	if len(c.Args()) == 0 {
+	if len(c.Args()) != 1 {
 		cmd.ui.FailWithUsage(c)
 	}
 

--- a/cf/commands/application/start_test.go
+++ b/cf/commands/application/start_test.go
@@ -209,7 +209,7 @@ var _ = Describe("start command", func() {
 			requirementsFactory.LoginSuccess = true
 		})
 
-		It("fails with usage when provided with no args", func() {
+		It("fails with usage when not provided exactly one arg", func() {
 			config := testconfig.NewRepository()
 			displayApp := &testcmd.FakeAppDisplayer{}
 			appRepo := &testApplication.FakeApplicationRepository{}

--- a/cf/commands/buildpack/buildpacks.go
+++ b/cf/commands/buildpack/buildpacks.go
@@ -32,6 +32,9 @@ func (cmd ListBuildpacks) Metadata() command_metadata.CommandMetadata {
 }
 
 func (cmd ListBuildpacks) GetRequirements(requirementsFactory requirements.Factory, c *cli.Context) (reqs []requirements.Requirement, err error) {
+	if len(c.Args()) != 0 {
+		cmd.ui.FailWithUsage(c)
+	}
 	reqs = []requirements.Requirement{
 		requirementsFactory.NewLoginRequirement(),
 	}

--- a/cf/commands/buildpack/buildpacks_test.go
+++ b/cf/commands/buildpack/buildpacks_test.go
@@ -31,6 +31,12 @@ var _ = Describe("ListBuildpacks", func() {
 		return testcmd.RunCommand(cmd, args, requirementsFactory)
 	}
 
+	It("should fail with usage when provided any arguments", func() {
+		requirementsFactory.LoginSuccess = true
+		Expect(runCommand("blahblah")).To(BeFalse())
+		Expect(ui.FailedWithUsage).To(BeTrue())
+	})
+
 	It("fails requirements when login fails", func() {
 		Expect(runCommand()).To(BeFalse())
 	})

--- a/cf/commands/environmentvariablegroup/running_environment_variable_group.go
+++ b/cf/commands/environmentvariablegroup/running_environment_variable_group.go
@@ -33,6 +33,9 @@ func (cmd RunningEnvironmentVariableGroup) Metadata() command_metadata.CommandMe
 }
 
 func (cmd RunningEnvironmentVariableGroup) GetRequirements(requirementsFactory requirements.Factory, c *cli.Context) ([]requirements.Requirement, error) {
+	if len(c.Args()) != 0 {
+		cmd.ui.FailWithUsage(c)
+	}
 	reqs := []requirements.Requirement{
 		requirementsFactory.NewLoginRequirement(),
 	}

--- a/cf/commands/environmentvariablegroup/running_environment_variable_group_test.go
+++ b/cf/commands/environmentvariablegroup/running_environment_variable_group_test.go
@@ -36,6 +36,11 @@ var _ = Describe("running-environment-variable-group command", func() {
 			requirementsFactory.LoginSuccess = false
 			Expect(runCommand()).ToNot(HavePassedRequirements())
 		})
+		It("should fail with usage when provided any arguments", func() {
+			requirementsFactory.LoginSuccess = true
+			Expect(runCommand("blahblah")).To(BeFalse())
+			Expect(ui.FailedWithUsage).To(BeTrue())
+		})
 	})
 
 	Describe("when logged in", func() {

--- a/cf/commands/environmentvariablegroup/staging_environment_variable_group.go
+++ b/cf/commands/environmentvariablegroup/staging_environment_variable_group.go
@@ -33,6 +33,9 @@ func (cmd StagingEnvironmentVariableGroup) Metadata() command_metadata.CommandMe
 }
 
 func (cmd StagingEnvironmentVariableGroup) GetRequirements(requirementsFactory requirements.Factory, c *cli.Context) ([]requirements.Requirement, error) {
+	if len(c.Args()) != 0 {
+		cmd.ui.FailWithUsage(c)
+	}
 	reqs := []requirements.Requirement{
 		requirementsFactory.NewLoginRequirement(),
 	}

--- a/cf/commands/environmentvariablegroup/staging_environment_variable_group_test.go
+++ b/cf/commands/environmentvariablegroup/staging_environment_variable_group_test.go
@@ -36,6 +36,11 @@ var _ = Describe("staging-environment-variable-group command", func() {
 			requirementsFactory.LoginSuccess = false
 			Expect(runCommand()).ToNot(HavePassedRequirements())
 		})
+		It("should fail with usage when provided any arguments", func() {
+			requirementsFactory.LoginSuccess = true
+			Expect(runCommand("blahblah")).To(BeFalse())
+			Expect(ui.FailedWithUsage).To(BeTrue())
+		})
 	})
 
 	Describe("when logged in", func() {

--- a/cf/commands/featureflag/feature_flags.go
+++ b/cf/commands/featureflag/feature_flags.go
@@ -35,7 +35,10 @@ func (cmd ListFeatureFlags) Metadata() command_metadata.CommandMetadata {
 	}
 }
 
-func (cmd ListFeatureFlags) GetRequirements(requirementsFactory requirements.Factory, _ *cli.Context) ([]requirements.Requirement, error) {
+func (cmd ListFeatureFlags) GetRequirements(requirementsFactory requirements.Factory, c *cli.Context) ([]requirements.Requirement, error) {
+	if len(c.Args()) != 0 {
+		cmd.ui.FailWithUsage(c)
+	}
 	reqs := []requirements.Requirement{
 		requirementsFactory.NewLoginRequirement(),
 	}

--- a/cf/commands/featureflag/feature_flags_test.go
+++ b/cf/commands/featureflag/feature_flags_test.go
@@ -38,6 +38,11 @@ var _ = Describe("feature-flags command", func() {
 			requirementsFactory.LoginSuccess = false
 			Expect(runCommand()).ToNot(HavePassedRequirements())
 		})
+		It("should fail with usage when provided any arguments", func() {
+			requirementsFactory.LoginSuccess = true
+			Expect(runCommand("blahblah")).To(BeFalse())
+			Expect(ui.FailedWithUsage).To(BeTrue())
+		})
 	})
 
 	Describe("when logged in", func() {

--- a/cf/commands/organization/orgs.go
+++ b/cf/commands/organization/orgs.go
@@ -33,6 +33,10 @@ func (cmd ListOrgs) Metadata() command_metadata.CommandMetadata {
 }
 
 func (cmd ListOrgs) GetRequirements(requirementsFactory requirements.Factory, c *cli.Context) (reqs []requirements.Requirement, err error) {
+	if len(c.Args()) != 0 {
+		cmd.ui.FailWithUsage(c)
+	}
+
 	reqs = []requirements.Requirement{
 		requirementsFactory.NewLoginRequirement(),
 	}

--- a/cf/commands/organization/orgs_test.go
+++ b/cf/commands/organization/orgs_test.go
@@ -23,9 +23,9 @@ var _ = Describe("org command", func() {
 		requirementsFactory *testreq.FakeReqFactory
 	)
 
-	runCommand := func() bool {
+	runCommand := func(args ...string) bool {
 		cmd := organization.NewListOrgs(ui, configRepo, orgRepo)
-		return testcmd.RunCommand(cmd, []string{}, requirementsFactory)
+		return testcmd.RunCommand(cmd, args, requirementsFactory)
 	}
 
 	BeforeEach(func() {
@@ -41,6 +41,12 @@ var _ = Describe("org command", func() {
 
 			Expect(runCommand()).To(BeFalse())
 		})
+		It("should fail with usage when provided any arguments", func() {
+			requirementsFactory.LoginSuccess = true
+			Expect(runCommand("blahblah")).To(BeFalse())
+			Expect(ui.FailedWithUsage).To(BeTrue())
+		})
+
 	})
 
 	Context("when there are orgs to be listed", func() {

--- a/cf/commands/plugin/plugins.go
+++ b/cf/commands/plugin/plugins.go
@@ -29,7 +29,10 @@ func (cmd *Plugins) Metadata() command_metadata.CommandMetadata {
 	}
 }
 
-func (cmd *Plugins) GetRequirements(_ requirements.Factory, _ *cli.Context) (req []requirements.Requirement, err error) {
+func (cmd *Plugins) GetRequirements(_ requirements.Factory, c *cli.Context) (req []requirements.Requirement, err error) {
+	if len(c.Args()) != 0 {
+		cmd.ui.FailWithUsage(c)
+	}
 	return
 }
 

--- a/cf/commands/plugin/plugins_test.go
+++ b/cf/commands/plugin/plugins_test.go
@@ -35,7 +35,11 @@ var _ = Describe("Plugins", func() {
 		cmd := NewPlugins(ui, config)
 		return testcmd.RunCommand(cmd, args, requirementsFactory)
 	}
-
+	It("should fail with usage when provided any arguments", func() {
+		requirementsFactory.LoginSuccess = true
+		Expect(runCommand("blahblah")).To(BeFalse())
+		Expect(ui.FailedWithUsage).To(BeTrue())
+	})
 	It("fails if the plugin cannot be started", func() {
 		config.PluginsReturns(map[string]plugin_config.PluginMetadata{
 			"test_245":     plugin_config.PluginMetadata{},

--- a/cf/commands/quota/quotas.go
+++ b/cf/commands/quota/quotas.go
@@ -37,6 +37,9 @@ func (cmd *ListQuotas) Metadata() command_metadata.CommandMetadata {
 }
 
 func (cmd *ListQuotas) GetRequirements(requirementsFactory requirements.Factory, c *cli.Context) (reqs []requirements.Requirement, err error) {
+	if len(c.Args()) != 0 {
+		cmd.ui.FailWithUsage(c)
+	}
 	reqs = []requirements.Requirement{
 		requirementsFactory.NewLoginRequirement(),
 	}

--- a/cf/commands/quota/quotas_test.go
+++ b/cf/commands/quota/quotas_test.go
@@ -28,15 +28,20 @@ var _ = Describe("quotas command", func() {
 		requirementsFactory = &testreq.FakeReqFactory{LoginSuccess: true}
 	})
 
-	runCommand := func() bool {
+	runCommand := func(args ...string) bool {
 		cmd := NewListQuotas(ui, testconfig.NewRepositoryWithDefaults(), quotaRepo)
-		return testcmd.RunCommand(cmd, []string{}, requirementsFactory)
+		return testcmd.RunCommand(cmd, args, requirementsFactory)
 	}
 
 	Describe("requirements", func() {
 		It("requires the user to be logged in", func() {
 			requirementsFactory.LoginSuccess = false
 			Expect(runCommand()).ToNot(HavePassedRequirements())
+		})
+		It("should fail with usage when provided any arguments", func() {
+			requirementsFactory.LoginSuccess = true
+			Expect(runCommand("blahblah")).To(BeFalse())
+			Expect(ui.FailedWithUsage).To(BeTrue())
 		})
 	})
 

--- a/cf/commands/route/delete_orphaned_routes.go
+++ b/cf/commands/route/delete_orphaned_routes.go
@@ -36,6 +36,9 @@ func (cmd DeleteOrphanedRoutes) Metadata() command_metadata.CommandMetadata {
 }
 
 func (cmd DeleteOrphanedRoutes) GetRequirements(reqFactory requirements.Factory, c *cli.Context) (reqs []requirements.Requirement, err error) {
+	if len(c.Args()) != 0 {
+		cmd.ui.FailWithUsage(c)
+	}
 	reqs = append(reqs, reqFactory.NewLoginRequirement())
 	return
 }

--- a/cf/commands/route/delete_orphaned_routes_test.go
+++ b/cf/commands/route/delete_orphaned_routes_test.go
@@ -27,6 +27,12 @@ var _ = Describe("delete-orphaned-routes command", func() {
 		_, passed := callDeleteOrphanedRoutes("y", []string{}, reqFactory, routeRepo)
 		Expect(passed).To(BeFalse())
 	})
+	It("should fail with usage when provided any arguments", func() {
+		reqFactory.LoginSuccess = true
+		ui, passed := callDeleteOrphanedRoutes("y", []string{"blahblah"}, reqFactory, routeRepo)
+		Expect(passed).To(BeFalse())
+		Expect(ui.FailedWithUsage).To(BeTrue())
+	})
 
 	Context("when logged in successfully", func() {
 

--- a/cf/commands/route/routes.go
+++ b/cf/commands/route/routes.go
@@ -36,6 +36,9 @@ func (cmd ListRoutes) Metadata() command_metadata.CommandMetadata {
 }
 
 func (cmd ListRoutes) GetRequirements(requirementsFactory requirements.Factory, c *cli.Context) ([]requirements.Requirement, error) {
+	if len(c.Args()) != 0 {
+		cmd.ui.FailWithUsage(c)
+	}
 	return []requirements.Requirement{
 		requirementsFactory.NewLoginRequirement(),
 		requirementsFactory.NewTargetedSpaceRequirement(),

--- a/cf/commands/route/routes_test.go
+++ b/cf/commands/route/routes_test.go
@@ -49,6 +49,12 @@ var _ = Describe("routes command", func() {
 
 			Expect(runCommand()).To(BeFalse())
 		})
+		It("should fail with usage when provided any arguments", func() {
+			requirementsFactory.LoginSuccess = true
+			requirementsFactory.TargetedSpaceSuccess = true
+			Expect(runCommand("blahblah")).To(BeFalse())
+			Expect(ui.FailedWithUsage).To(BeTrue())
+		})
 	})
 
 	Context("when there are routes", func() {

--- a/cf/commands/service/delete_service.go
+++ b/cf/commands/service/delete_service.go
@@ -39,16 +39,9 @@ func (cmd *DeleteService) Metadata() command_metadata.CommandMetadata {
 }
 
 func (cmd *DeleteService) GetRequirements(requirementsFactory requirements.Factory, c *cli.Context) (reqs []requirements.Requirement, err error) {
-	var serviceName string
-
-	if len(c.Args()) == 1 {
-		serviceName = c.Args()[0]
-	}
-
-	if serviceName == "" {
+	if len(c.Args()) != 1 {
 		cmd.ui.FailWithUsage(c)
 	}
-
 	reqs = []requirements.Requirement{requirementsFactory.NewLoginRequirement()}
 	return
 }

--- a/cf/commands/service/delete_service_test.go
+++ b/cf/commands/service/delete_service_test.go
@@ -54,7 +54,7 @@ var _ = Describe("delete-service command", func() {
 			requirementsFactory.LoginSuccess = true
 		})
 
-		It("fails with usage when no service name is given", func() {
+		It("fails with usage when not provided exactly one arg", func() {
 			runCommand()
 			Expect(ui.FailedWithUsage).To(BeTrue())
 		})

--- a/cf/commands/service/marketplace.go
+++ b/cf/commands/service/marketplace.go
@@ -43,6 +43,9 @@ func (cmd MarketplaceServices) Metadata() command_metadata.CommandMetadata {
 }
 
 func (cmd MarketplaceServices) GetRequirements(requirementsFactory requirements.Factory, c *cli.Context) (reqs []requirements.Requirement, err error) {
+	if len(c.Args()) != 0 {
+		cmd.ui.FailWithUsage(c)
+	}
 	reqs = append(reqs, requirementsFactory.NewApiEndpointRequirement())
 	return
 }

--- a/cf/commands/service/marketplace_test.go
+++ b/cf/commands/service/marketplace_test.go
@@ -60,6 +60,13 @@ var _ = Describe("marketplace command", func() {
 
 				Expect(testcmd.RunCommand(cmd, []string{}, requirementsFactory)).To(BeFalse())
 			})
+			It("should fail with usage when provided any arguments", func() {
+				config := testconfig.NewRepository()
+				cmd := NewMarketplaceServices(ui, config, serviceBuilder)
+				requirementsFactory.ApiEndpointSuccess = true
+				Expect(testcmd.RunCommand(cmd, []string{"blahblah"}, requirementsFactory)).To(BeFalse())
+				Expect(ui.FailedWithUsage).To(BeTrue())
+			})
 		})
 	})
 

--- a/cf/commands/service/services.go
+++ b/cf/commands/service/services.go
@@ -35,6 +35,9 @@ func (cmd ListServices) Metadata() command_metadata.CommandMetadata {
 }
 
 func (cmd ListServices) GetRequirements(requirementsFactory requirements.Factory, c *cli.Context) (reqs []requirements.Requirement, err error) {
+	if len(c.Args()) != 0 {
+		cmd.ui.FailWithUsage(c)
+	}
 	reqs = append(reqs,
 		requirementsFactory.NewLoginRequirement(),
 		requirementsFactory.NewTargetedSpaceRequirement(),

--- a/cf/commands/service/services_test.go
+++ b/cf/commands/service/services_test.go
@@ -58,6 +58,12 @@ var _ = Describe("services", func() {
 				Expect(testcmd.RunCommand(cmd, []string{}, requirementsFactory)).To(BeFalse())
 			})
 		})
+		It("should fail with usage when provided any arguments", func() {
+			requirementsFactory.LoginSuccess = true
+			requirementsFactory.TargetedSpaceSuccess = true
+			Expect(testcmd.RunCommand(cmd, []string{"blahblah"}, requirementsFactory)).To(BeFalse())
+			Expect(ui.FailedWithUsage).To(BeTrue())
+		})
 	})
 
 	It("lists available services", func() {

--- a/cf/commands/service/update_service.go
+++ b/cf/commands/service/update_service.go
@@ -43,7 +43,7 @@ func (cmd *UpdateService) Metadata() command_metadata.CommandMetadata {
 }
 
 func (cmd *UpdateService) GetRequirements(requirementsFactory requirements.Factory, c *cli.Context) (reqs []requirements.Requirement, err error) {
-	if len(c.Args()) < 1 {
+	if len(c.Args()) != 1 {
 		cmd.ui.FailWithUsage(c)
 	}
 

--- a/cf/commands/service/update_service_test.go
+++ b/cf/commands/service/update_service_test.go
@@ -56,10 +56,10 @@ var _ = Describe("update-service command", func() {
 
 	Describe("requirements", func() {
 		It("passes when logged in and a space is targeted", func() {
-			Expect(callUpdateService([]string{"cleardb", "spark", "my-cleardb-service"})).To(BeTrue())
+			Expect(callUpdateService([]string{"cleardb"})).To(BeTrue())
 		})
 
-		It("fails when there are 0 arguments", func() {
+		It("fails with usage when not provided exactly one arg", func() {
 			Expect(callUpdateService([]string{})).To(BeFalse())
 		})
 

--- a/cf/commands/serviceaccess/service_access.go
+++ b/cf/commands/serviceaccess/service_access.go
@@ -46,6 +46,9 @@ func (cmd *ServiceAccess) Metadata() command_metadata.CommandMetadata {
 }
 
 func (cmd *ServiceAccess) GetRequirements(requirementsFactory requirements.Factory, c *cli.Context) (reqs []requirements.Requirement, err error) {
+	if len(c.Args()) != 0 {
+		cmd.ui.FailWithUsage(c)
+	}
 	reqs = []requirements.Requirement{
 		requirementsFactory.NewLoginRequirement(),
 	}

--- a/cf/commands/serviceaccess/service_access_test.go
+++ b/cf/commands/serviceaccess/service_access_test.go
@@ -44,6 +44,11 @@ var _ = Describe("service-access command", func() {
 			requirementsFactory.LoginSuccess = false
 			Expect(runCommand()).ToNot(HavePassedRequirements())
 		})
+		It("should fail with usage when provided any arguments", func() {
+			requirementsFactory.LoginSuccess = true
+			Expect(runCommand("blahblah")).To(BeFalse())
+			Expect(ui.FailedWithUsage).To(BeTrue())
+		})
 	})
 
 	Describe("when logged in", func() {
@@ -85,7 +90,7 @@ var _ = Describe("service-access command", func() {
 		})
 
 		It("refreshes the auth token", func() {
-			runCommand("service")
+			runCommand()
 			Expect(tokenRefresher.RefreshTokenCalled).To(BeTrue())
 		})
 

--- a/cf/commands/serviceauthtoken/service_auth_tokens.go
+++ b/cf/commands/serviceauthtoken/service_auth_tokens.go
@@ -32,6 +32,9 @@ func (cmd ListServiceAuthTokens) Metadata() command_metadata.CommandMetadata {
 }
 
 func (cmd ListServiceAuthTokens) GetRequirements(requirementsFactory requirements.Factory, c *cli.Context) (reqs []requirements.Requirement, err error) {
+	if len(c.Args()) != 0 {
+		cmd.ui.FailWithUsage(c)
+	}
 	reqs = []requirements.Requirement{
 		requirementsFactory.NewLoginRequirement(),
 	}

--- a/cf/commands/serviceauthtoken/service_auth_tokens_test.go
+++ b/cf/commands/serviceauthtoken/service_auth_tokens_test.go
@@ -49,6 +49,11 @@ var _ = Describe("service-auth-tokens command", func() {
 		It("fails when not logged in", func() {
 			Expect(runCommand()).To(BeFalse())
 		})
+		It("should fail with usage when provided any arguments", func() {
+			requirementsFactory.LoginSuccess = true
+			Expect(runCommand("blahblah")).To(BeFalse())
+			Expect(ui.FailedWithUsage).To(BeTrue())
+		})
 	})
 
 	Context("when logged in and some service auth tokens exist", func() {

--- a/cf/commands/servicebroker/service_brokers.go
+++ b/cf/commands/servicebroker/service_brokers.go
@@ -33,6 +33,9 @@ func (cmd ListServiceBrokers) Metadata() command_metadata.CommandMetadata {
 }
 
 func (cmd ListServiceBrokers) GetRequirements(requirementsFactory requirements.Factory, c *cli.Context) (reqs []requirements.Requirement, err error) {
+	if len(c.Args()) != 0 {
+		cmd.ui.FailWithUsage(c)
+	}
 	reqs = append(reqs, requirementsFactory.NewLoginRequirement())
 	return
 }

--- a/cf/commands/servicebroker/service_brokers_test.go
+++ b/cf/commands/servicebroker/service_brokers_test.go
@@ -46,6 +46,11 @@ var _ = Describe("service-brokers command", func() {
 			requirementsFactory.LoginSuccess = false
 			Expect(testcmd.RunCommand(cmd, []string{}, requirementsFactory)).To(BeFalse())
 		})
+		It("should fail with usage when provided any arguments", func() {
+			requirementsFactory.LoginSuccess = true
+			Expect(testcmd.RunCommand(cmd, []string{"blahblah"}, requirementsFactory)).To(BeFalse())
+			Expect(ui.FailedWithUsage).To(BeTrue())
+		})
 	})
 
 	It("lists service brokers", func() {

--- a/cf/commands/space/spaces.go
+++ b/cf/commands/space/spaces.go
@@ -33,6 +33,9 @@ func (cmd ListSpaces) Metadata() command_metadata.CommandMetadata {
 }
 
 func (cmd ListSpaces) GetRequirements(requirementsFactory requirements.Factory, c *cli.Context) (reqs []requirements.Requirement, err error) {
+	if len(c.Args()) != 0 {
+		cmd.ui.FailWithUsage(c)
+	}
 	reqs = []requirements.Requirement{
 		requirementsFactory.NewLoginRequirement(),
 		requirementsFactory.NewTargetedOrgRequirement(),

--- a/cf/commands/space/spaces_test.go
+++ b/cf/commands/space/spaces_test.go
@@ -54,6 +54,11 @@ var _ = Describe("spaces command", func() {
 
 			Expect(runCommand()).To(BeFalse())
 		})
+		It("should fail with usage when provided any arguments", func() {
+			requirementsFactory.LoginSuccess = true
+			Expect(runCommand("blahblah")).To(BeFalse())
+			Expect(ui.FailedWithUsage).To(BeTrue())
+		})
 	})
 
 	Context("when logged in and an org is targeted", func() {

--- a/cf/commands/spacequota/space_quotas.go
+++ b/cf/commands/spacequota/space_quotas.go
@@ -37,6 +37,9 @@ func (cmd *ListSpaceQuotas) Metadata() command_metadata.CommandMetadata {
 }
 
 func (cmd *ListSpaceQuotas) GetRequirements(requirementsFactory requirements.Factory, c *cli.Context) (reqs []requirements.Requirement, err error) {
+	if len(c.Args()) != 0 {
+		cmd.ui.FailWithUsage(c)
+	}
 	reqs = []requirements.Requirement{
 		requirementsFactory.NewLoginRequirement(),
 		requirementsFactory.NewTargetedOrgRequirement(),

--- a/cf/commands/spacequota/space_quotas_test.go
+++ b/cf/commands/spacequota/space_quotas_test.go
@@ -28,9 +28,9 @@ var _ = Describe("quotas command", func() {
 		requirementsFactory = &testreq.FakeReqFactory{LoginSuccess: true}
 	})
 
-	runCommand := func() bool {
+	runCommand := func(args ...string) bool {
 		cmd := NewListSpaceQuotas(ui, testconfig.NewRepositoryWithDefaults(), quotaRepo)
-		return testcmd.RunCommand(cmd, []string{}, requirementsFactory)
+		return testcmd.RunCommand(cmd, args, requirementsFactory)
 	}
 
 	Describe("requirements", func() {
@@ -42,6 +42,12 @@ var _ = Describe("quotas command", func() {
 		It("requires the user to target an org", func() {
 			requirementsFactory.TargetedOrgSuccess = false
 			Expect(runCommand()).ToNot(HavePassedRequirements())
+		})
+		It("should fail with usage when provided any arguments", func() {
+			requirementsFactory.LoginSuccess = true
+			requirementsFactory.TargetedOrgSuccess = true
+			Expect(runCommand("blahblah")).To(BeFalse())
+			Expect(ui.FailedWithUsage).To(BeTrue())
 		})
 	})
 


### PR DESCRIPTION
'cf orgs blhablah'
'cf spaces blahblah'
'cf update-service SERVICE blahblah'
'cf marketplace  blahblah'
'cf delete-service SERVICE_INSTANCE  blahblah'
'cf services blahblah'
'cf plugins blahblah'
'cf feature-flags blahblah'
'cf create-space my-space blahablaha'
'cf app APPNAME  blahablaha'
'cf delete APPNAME blahblah'
'cf service-access blahblah'
'cf service-auth-tokens blahblah'
'cf service-brokers blahblah'
'cf delete-orphaned-routes'
'cf apps blahblah'
'cf restart APP blahblah'
'cf buildpacks blahblah'
'cf running-environment-variable-group  blahblah'
'cf staging-environment-variable-group  blahblah'
'cf space-quotas blahblah'
'cf quotas  blahblah'
'cf routes blahblah'
'cf start APP blahblah'

for example
Before Fix: If cf user does
'cf orgs  blahblah'
the command is success but ignord the second argument

After Fix:If cf user does
'cf orgs  blahblah'
the command will with proper reason

http://rnd-github.huawei.com/paas/cli/issues/2
