### PR TITLE
Fix in clearing spacefileds of config data on 'cf space-delete' 

### DIFF
--- a/cf/commands/space/delete_space.go
+++ b/cf/commands/space/delete_space.go
@@ -78,7 +78,7 @@ func (cmd *DeleteSpace) Run(c *cli.Context) {
 
 	cmd.ui.Ok()
 
-	if cmd.config.SpaceFields().Name == spaceName {
+	if cmd.config.SpaceFields().Guid == space.Guid {
 		cmd.config.SetSpaceFields(models.SpaceFields{})
 		cmd.ui.Say(T("TIP: No space targeted, use '{{.CfTargetCommand}}' to target a space",
 			map[string]interface{}{"CfTargetCommand": cf.Name() + " target -s"}))

--- a/cf/commands/space/delete_space_test.go
+++ b/cf/commands/space/delete_space_test.go
@@ -94,4 +94,11 @@ var _ = Describe("delete-space command", func() {
 
 		Expect(config.HasSpace()).To(Equal(false))
 	})
+
+	It("clears the space from the config, when deleting the space currently targeted even if space name is case insensitive", func() {
+		config.SetSpaceFields(space.SpaceFields)
+		runCommand("-f", "Space-To-Delete")
+
+		Expect(config.HasSpace()).To(Equal(false))
+	})
 })


### PR DESCRIPTION
Before Fix: If cf user does
htipl@cf5:~/go/src/github.com/cloudfoundry/cli$ cf target
API endpoint:   https://api.10.244.0.34.xip.io (API version: 2.13.0)
User:           admin
Org:            SriniOrg
Space:          SriniSpace
htipl@cf5:~/go/src/github.com/cloudfoundry/cli$ cf spaces
Getting spaces in org SriniOrg as admin...
name
SriniSpace
htipl@cf5:~/go/src/github.com/cloudfoundry/cli$ cf delete-space srinispace
Really delete the space srinispace?> y
Deleting space srinispace in org SriniOrg as admin...
OK
htipl@cf5:~/go/src/github.com/cloudfoundry/cli$ cf spaces
Getting spaces in org SriniOrg as admin...
name
No spaces found
htipl@cf5:~/go/src/github.com/cloudfoundry/cli$ cf target
API endpoint:   https://api.10.244.0.34.xip.io (API version: 2.13.0)
User:           admin
Org:            SriniOrg
Space:          SriniSpace

After Fix:If cf user does
htipl@cf5:~/go/src/github.com/cloudfoundry/cli$ ./out/cf target

API endpoint:   https://api.10.244.0.34.xip.io (API version: 2.13.0)
User:           admin
Org:            SriniOrg
Space:          SriniSpace
htipl@cf5:~/go/src/github.com/cloudfoundry/cli$ ./out/cf spaces
Getting spaces in org SriniOrg as admin...
name
SriniSpace
htipl@cf5:~/go/src/github.com/cloudfoundry/cli$ ./out/cf delete-space srinispace
Really delete the space srinispace?> y
Deleting space srinispace in org SriniOrg as admin...
OK
TIP: No space targeted, use 'cf target -s' to target a space
htipl@cf5:~/go/src/github.com/cloudfoundry/cli$ ./out/cf spaces
Getting spaces in org SriniOrg as admin...
name
No spaces found
htipl@cf5:~/go/src/github.com/cloudfoundry/cli$ ./out/cf target
API endpoint:   https://api.10.244.0.34.xip.io (API version: 2.13.0)
User:           admin
Org:            SriniOrg
Space:          No space targeted, use 'cf target -s SPACE'

http://rnd-github.huawei.com/paas/cli/issues/28
