### PR TITLE
Fix the invalid memory address during bind service

### DIFF
--- a/cf/api/fakes/fake_service_binding_repo.go
+++ b/cf/api/fakes/fake_service_binding_repo.go
@@ -13,11 +13,16 @@ type FakeServiceBindingRepo struct {
 	DeleteServiceInstance models.ServiceInstance
 	DeleteApplicationGuid string
 	DeleteBindingNotFound bool
+	CreateNonHttpErrCode  string
 }
 
 func (repo *FakeServiceBindingRepo) Create(instanceGuid, appGuid string) (apiErr error) {
 	repo.CreateServiceInstanceGuid = instanceGuid
 	repo.CreateApplicationGuid = appGuid
+	if repo.CreateNonHttpErrCode != "" {
+		apiErr = errors.New(repo.CreateNonHttpErrCode)
+		return
+	}
 
 	if repo.CreateErrorCode != "" {
 		apiErr = errors.NewHttpError(400, repo.CreateErrorCode, "Error binding service")

--- a/cf/commands/service/bind_service.go
+++ b/cf/commands/service/bind_service.go
@@ -73,7 +73,7 @@ func (cmd *BindService) Run(c *cli.Context) {
 
 	err := cmd.BindApplication(app, serviceInstance)
 	if err != nil {
-		if err, ok := err.(errors.HttpError); ok && err.ErrorCode() == errors.APP_ALREADY_BOUND {
+		if httperr, ok := err.(errors.HttpError); ok && httperr.ErrorCode() == errors.APP_ALREADY_BOUND {
 			cmd.ui.Ok()
 			cmd.ui.Warn(T("App {{.AppName}} is already bound to {{.ServiceName}}.",
 				map[string]interface{}{

--- a/cf/commands/service/bind_service_test.go
+++ b/cf/commands/service/bind_service_test.go
@@ -78,6 +78,24 @@ var _ = Describe("bind-service command", func() {
 			))
 		})
 
+		It("warns the user when the error is non HttpError ", func() {
+			app := models.Application{}
+			app.Name = "my-app1"
+			app.Guid = "my-app1-guid1"
+			serviceInstance := models.ServiceInstance{}
+			serviceInstance.Name = "my-service1"
+			serviceInstance.Guid = "my-service1-guid1"
+			requirementsFactory.Application = app
+			requirementsFactory.ServiceInstance = serviceInstance
+			serviceBindingRepo := &testapi.FakeServiceBindingRepo{CreateNonHttpErrCode: "1001"}
+			ui := callBindService([]string{"my-app1", "my-service1"}, requirementsFactory, serviceBindingRepo)
+			Expect(ui.Outputs).To(ContainSubstrings(
+				[]string{"Binding service", "my-service", "my-app", "my-org", "my-space", "my-user"},
+				[]string{"FAILED"},
+				[]string{"1001"},
+			))
+		})
+
 		It("fails with usage when called without a service instance and app", func() {
 			serviceBindingRepo := &testapi.FakeServiceBindingRepo{}
 


### PR DESCRIPTION
Solution to the bug:- [#79267756]
During Bind a service instance to an app if cli receives a non http error
then err parameter is nil, so cli is panic because its accessing the nil pointer err
so to over come that use a new httperr variable inside the if condition

http://rnd-github.huawei.com/cloudfoundry/cli/issues/1
