### PR TITLE
Fix attempts to create service even when no space is targeted

### DIFF
--- a/cf/commands/service/create_user_provided_service.go
+++ b/cf/commands/service/create_user_provided_service.go
@@ -57,7 +57,10 @@ func (cmd CreateUserProvidedService) GetRequirements(requirementsFactory require
 		cmd.ui.FailWithUsage(c)
 	}
 
-	reqs = append(reqs, requirementsFactory.NewLoginRequirement())
+	reqs = []requirements.Requirement{
+		requirementsFactory.NewLoginRequirement(),
+		requirementsFactory.NewTargetedSpaceRequirement(),
+	}
 	return
 }
 

--- a/cf/commands/service/create_user_provided_service_test.go
+++ b/cf/commands/service/create_user_provided_service_test.go
@@ -27,13 +27,17 @@ var _ = Describe("create-user-provided-service command", func() {
 		ui = &testterm.FakeUI{}
 		config = testconfig.NewRepositoryWithDefaults()
 		repo = &testapi.FakeUserProvidedServiceInstanceRepo{}
-		requirementsFactory = &testreq.FakeReqFactory{LoginSuccess: true}
+		requirementsFactory = &testreq.FakeReqFactory{LoginSuccess: true, TargetedSpaceSuccess: true}
 		cmd = NewCreateUserProvidedService(ui, config, repo)
 	})
 
 	Describe("login requirements", func() {
 		It("fails if the user is not logged in", func() {
 			requirementsFactory.LoginSuccess = false
+			Expect(testcmd.RunCommand(cmd, []string{"my-service"}, requirementsFactory)).To(BeFalse())
+		})
+		It("fails when a space is not targeted", func() {
+			requirementsFactory.TargetedSpaceSuccess = false
 			Expect(testcmd.RunCommand(cmd, []string{"my-service"}, requirementsFactory)).To(BeFalse())
 		})
 	})


### PR DESCRIPTION
Solution to the bug:- [#82753668]
CLI creating user provided service without targetting the space but CLI is receiving
the  error from CC,So to avoid communication with CC in invalid condition, added the
validation for space is targetted or not in CLI before sending the http request to CC.

Before Fix: If cf user does 'cf cups pubsub' without targetting the org & space

cf@cf3:~/.go/src/github.com/cloudfoundry/cli$ cf cups pubsub
Creating user provided service pubsub in org  / space  as admin...
FAILED
Server error, status code: 400, error code: 1002, message: Invalid relation: Could not find VCAP:
:CloudController::Space with guid:

So CLI is sending empty space guid & receiving error from cloud controller which we can validate at CLI it self.

After Fix:If cf user does same steps
cf@cf3:~/.go/src/github.com/cloudfoundry/cli$ ./out/cf cups pubs
FAILED
No org and space targeted, use 'cf target -o ORG -s SPACE' to target an org and space


http://rnd-github.huawei.com/cloudfoundry/cli/issues/3