### PR TITLE
Added way to put user in org's space with 'cf target -o ORG' command if there is only one space

### DIFF
--- a/cf/commands/target.go
+++ b/cf/commands/target.go
@@ -70,6 +70,11 @@ func (cmd Target) Run(c *cli.Context) {
 		err := cmd.setOrganization(orgName)
 		if err != nil {
 			cmd.ui.Failed(err.Error())
+		} else if spaceName == "" {
+			spaceList, apiErr := cmd.getSpaceList()
+			if apiErr == nil && len(spaceList) == 1 {
+				cmd.setSpace(spaceList[0].Name)
+			}
 		}
 	}
 
@@ -117,4 +122,14 @@ func (cmd Target) setSpace(spaceName string) error {
 
 	cmd.config.SetSpaceFields(space.SpaceFields)
 	return nil
+}
+
+func (cmd Target) getSpaceList() ([]models.Space, error) {
+	spaceList := []models.Space{}
+	apiErr := cmd.spaceRepo.ListSpaces(
+		func(space models.Space) bool {
+			spaceList = append(spaceList, space)
+			return true
+		})
+	return spaceList, apiErr
 }


### PR DESCRIPTION
cf target with [-o] flag will internally target organization's space if there is only one space .

Story ID : #73568408

For Example :
If testOrg has only one space testspace then

Command line output with old Implementation :
```
$ cf target -o testOrg

API endpoint:   https://api.10.244.0.34.xip.io (API version: 2.22.0)
User:           admin
Org:            testOrg
Space:          No space targeted, use 'cf target -s SPACE'
```
Command line output with new Implementation:
```
$ cf target -o testOrg

API endpoint:   https://api.10.244.0.34.xip.io (API version: 2.22.0)
User:           admin
Org:            testOrg
Space:        testspace
```

Issue Created in tracker : http://rnd-github.huawei.com/cloudfoundry/cli/issues/17