### PR TITLE
Fixing `spaces` displays 'name' column heading even when requests fail

### DIFF
--- a/cf/commands/space/spaces.go
+++ b/cf/commands/space/spaces.go
@@ -57,7 +57,6 @@ func (cmd ListSpaces) Run(c *cli.Context) {
 		foundSpaces = true
 		return true
 	})
-	table.Print()
 
 	if apiErr != nil {
 		cmd.ui.Failed(T("Failed fetching spaces.\n{{.ErrorDescription}}",
@@ -66,6 +65,8 @@ func (cmd ListSpaces) Run(c *cli.Context) {
 			}))
 		return
 	}
+
+	table.Print()
 
 	if !foundSpaces {
 		cmd.ui.Say(T("No spaces found"))


### PR DESCRIPTION
Before :  If apiErr happens still it will display the Spaces column heading
After    :  If apiErr happens then it will only display the apiErr message

Issue : https://www.pivotaltracker.com/story/show/90794162