### PR TITLE
Added command to get quota usage for org

### DIFF
--- a/cf/api/organizations/fakes/fake_organization_repository.go
+++ b/cf/api/organizations/fakes/fake_organization_repository.go
@@ -68,6 +68,15 @@ type FakeOrganizationRepository struct {
 	unsharePrivateDomainReturns struct {
 		result1 error
 	}
+	GetOrganizationQuotaUsageStub        func(orgGuid string) (quotaUsage models.QuotaUsage, apiErr error)
+	getOrganizationQuotaUsageMutex       sync.RWMutex
+	getOrganizationQuotaUsageArgsForCall []struct {
+		quotaUsage models.QuotaUsage
+	}
+	getOrganizationQuotaUsageReturns struct {
+		result1 models.QuotaUsage
+		result2 error
+	}
 }
 
 func (fake *FakeOrganizationRepository) ListOrgs() (orgs []models.Organization, apiErr error) {
@@ -91,6 +100,39 @@ func (fake *FakeOrganizationRepository) ListOrgsReturns(result1 []models.Organiz
 	fake.ListOrgsStub = nil
 	fake.listOrgsReturns = struct {
 		result1 []models.Organization
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeOrganizationRepository) GetOrganizationQuotaUsage(orgGuid string) (quotaUsage models.QuotaUsage, apiErr error) {
+	fake.getOrganizationQuotaUsageMutex.Lock()
+	fake.getOrganizationQuotaUsageArgsForCall = append(fake.getOrganizationQuotaUsageArgsForCall, struct {
+		quotaUsage models.QuotaUsage
+	}{quotaUsage})
+	fake.getOrganizationQuotaUsageMutex.Unlock()
+	if fake.GetOrganizationQuotaUsageStub != nil {
+		return fake.GetOrganizationQuotaUsageStub(orgGuid)
+	} else {
+		return fake.getOrganizationQuotaUsageReturns.result1, fake.getOrganizationQuotaUsageReturns.result2
+	}
+}
+
+func (fake *FakeOrganizationRepository) GetOrganizationQuotaUsageCallCount() int {
+	fake.getOrganizationQuotaUsageMutex.RLock()
+	defer fake.getOrganizationQuotaUsageMutex.RUnlock()
+	return len(fake.getOrganizationQuotaUsageArgsForCall)
+}
+
+func (fake *FakeOrganizationRepository) GetOrganizationQuotaUsageArgsForCall(i int) models.QuotaUsage {
+	fake.getOrganizationQuotaUsageMutex.RLock()
+	defer fake.getOrganizationQuotaUsageMutex.RUnlock()
+	return fake.getOrganizationQuotaUsageArgsForCall[i].quotaUsage
+}
+
+func (fake *FakeOrganizationRepository) GetOrganizationQuotaUsageReturns(result1 models.QuotaUsage, result2 error) {
+	fake.GetOrganizationQuotaUsageStub = nil
+	fake.getOrganizationQuotaUsageReturns = struct {
+		result1 models.QuotaUsage
 		result2 error
 	}{result1, result2}
 }

--- a/cf/api/organizations/organizations.go
+++ b/cf/api/organizations/organizations.go
@@ -21,6 +21,7 @@ type OrganizationRepository interface {
 	Delete(orgGuid string) (apiErr error)
 	SharePrivateDomain(orgGuid string, domainGuid string) (apiErr error)
 	UnsharePrivateDomain(orgGuid string, domainGuid string) (apiErr error)
+	GetOrganizationQuotaUsage(orgGuid string) (quotaUsage models.QuotaUsage, apiErr error)
 }
 
 type CloudControllerOrganizationRepository struct {
@@ -69,6 +70,18 @@ func (repo CloudControllerOrganizationRepository) FindByName(name string) (org m
 	}
 
 	return
+}
+
+func (repo CloudControllerOrganizationRepository) GetOrganizationQuotaUsage(orgGuid string) (models.QuotaUsage, error) {
+	url := fmt.Sprintf("%s/v2/organizations/%s/quota_usage", repo.config.ApiEndpoint(), orgGuid)
+
+	quotaUsageResource := new(resources.QuotaUsageResource)
+	err := repo.gateway.GetResource(url, quotaUsageResource)
+	if err != nil {
+		return models.QuotaUsage{}, err
+	}
+
+	return quotaUsageResource.ToFields(), nil
 }
 
 func (repo CloudControllerOrganizationRepository) Create(org models.Organization) (apiErr error) {

--- a/cf/api/resources/quotas.go
+++ b/cf/api/resources/quotas.go
@@ -11,6 +11,11 @@ type QuotaResource struct {
 	Entity models.QuotaFields
 }
 
+type QuotaUsageResource struct {
+	Resource
+	Entity models.QuotaUsage
+}
+
 func (resource QuotaResource) ToFields() (quota models.QuotaFields) {
 	quota.Guid = resource.Metadata.Guid
 	quota.Name = resource.Entity.Name
@@ -19,5 +24,19 @@ func (resource QuotaResource) ToFields() (quota models.QuotaFields) {
 	quota.RoutesLimit = resource.Entity.RoutesLimit
 	quota.ServicesLimit = resource.Entity.ServicesLimit
 	quota.NonBasicServicesAllowed = resource.Entity.NonBasicServicesAllowed
+	return
+}
+
+func (resource QuotaUsageResource) ToFields() (quotaUsage models.QuotaUsage) {
+	quotaUsage.Guid = resource.Metadata.Guid
+	quotaUsage.Name = resource.Entity.Name
+	quotaUsage.MemoryLimit = resource.Entity.MemoryLimit
+	quotaUsage.InstanceMemoryLimit = resource.Entity.InstanceMemoryLimit
+	quotaUsage.RoutesLimit = resource.Entity.RoutesLimit
+	quotaUsage.ServicesLimit = resource.Entity.ServicesLimit
+	quotaUsage.NonBasicServicesAllowed = resource.Entity.NonBasicServicesAllowed
+	quotaUsage.OrgUsage.Routes = resource.Entity.OrgUsage.Routes
+	quotaUsage.OrgUsage.Services = resource.Entity.OrgUsage.Services
+	quotaUsage.OrgUsage.Memory = resource.Entity.OrgUsage.Memory
 	return
 }

--- a/cf/app/help.go
+++ b/cf/app/help.go
@@ -189,6 +189,7 @@ func newAppPresenter(app *cli.App) (presenter appPresenter) {
 					presentCommand("create-org"),
 					presentCommand("delete-org"),
 					presentCommand("rename-org"),
+					presentCommand("org-quota-usage"),
 				},
 			},
 		}, {

--- a/cf/command_factory/factory.go
+++ b/cf/command_factory/factory.go
@@ -129,6 +129,7 @@ func NewFactory(ui terminal.UI, config core_config.ReadWriter, manifestRepo mani
 	factory.cmdsByName["oauth-token"] = commands.NewOAuthToken(ui, config, repoLocator.GetAuthenticationRepository())
 	factory.cmdsByName["org"] = organization.NewShowOrg(ui, config)
 	factory.cmdsByName["org-users"] = user.NewOrgUsers(ui, config, repoLocator.GetUserRepository())
+	factory.cmdsByName["org-quota-usage"] = organization.NewQuotaUsage(ui, config, repoLocator.GetOrganizationRepository())
 	factory.cmdsByName["orgs"] = organization.NewListOrgs(ui, config, repoLocator.GetOrganizationRepository())
 	factory.cmdsByName["passwd"] = commands.NewPassword(ui, repoLocator.GetPasswordRepository(), config)
 	factory.cmdsByName["purge-service-offering"] = service.NewPurgeServiceOffering(ui, config, repoLocator.GetServiceRepository())

--- a/cf/commands/organization/org_quota_usage.go
+++ b/cf/commands/organization/org_quota_usage.go
@@ -1,0 +1,81 @@
+package organization
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/cloudfoundry/cli/cf/api/organizations"
+	"github.com/cloudfoundry/cli/cf/command_metadata"
+	"github.com/cloudfoundry/cli/cf/configuration/core_config"
+	"github.com/cloudfoundry/cli/cf/formatters"
+	. "github.com/cloudfoundry/cli/cf/i18n"
+	"github.com/cloudfoundry/cli/cf/requirements"
+	"github.com/cloudfoundry/cli/cf/terminal"
+	"github.com/codegangsta/cli"
+)
+
+type GetQuotaUsage struct {
+	ui      terminal.UI
+	config  core_config.Reader
+	orgRepo organizations.OrganizationRepository
+}
+
+func NewQuotaUsage(ui terminal.UI, config core_config.Reader, orgRepo organizations.OrganizationRepository) (cmd *GetQuotaUsage) {
+	cmd = new(GetQuotaUsage)
+	cmd.ui = ui
+	cmd.config = config
+	cmd.orgRepo = orgRepo
+	return
+}
+
+func (cmd *GetQuotaUsage) Metadata() command_metadata.CommandMetadata {
+	return command_metadata.CommandMetadata{
+		Name:        "org-quota-usage",
+		Description: T("Get quota usage for org"),
+		Usage:       T("CF_NAME org-quota-usage ORG_NAME \n\n") + T("TIP:\n") + T("View all organizations with 'CF_NAME orgs'"),
+	}
+}
+
+func (cmd *GetQuotaUsage) GetRequirements(requirementsFactory requirements.Factory, c *cli.Context) (reqs []requirements.Requirement, err error) {
+	if len(c.Args()) != 1 {
+		cmd.ui.FailWithUsage(c)
+	}
+
+	reqs = []requirements.Requirement{
+		requirementsFactory.NewLoginRequirement(),
+	}
+	return
+}
+
+func (cmd *GetQuotaUsage) Run(c *cli.Context) {
+	orgName := c.Args()[0]
+
+	cmd.ui.Say(T("Getting quota usage info for org {{.OrgName}} as {{.Username}}...",
+		map[string]interface{}{
+			"OrgName":  terminal.EntityNameColor(orgName),
+			"Username": terminal.EntityNameColor(cmd.config.Username())}))
+
+	org, err := cmd.orgRepo.FindByName(orgName)
+
+	if err != nil {
+		cmd.ui.Failed(err.Error())
+	}
+
+	quotaUsage, apiErr := cmd.orgRepo.GetOrganizationQuotaUsage(org.Guid)
+	if apiErr != nil {
+		cmd.ui.Failed(apiErr.Error())
+	}
+
+	servicesLimit := strconv.Itoa(quotaUsage.ServicesLimit)
+	if servicesLimit == "-1" {
+		servicesLimit = T("unlimited")
+	}
+
+	table := terminal.NewTable(cmd.ui, []string{"", ""})
+	table.Add(T("Routes"), fmt.Sprintf("%d/%d", quotaUsage.OrgUsage.Routes, quotaUsage.RoutesLimit))
+	table.Add(T("Services"), fmt.Sprintf("%s/%s", strconv.Itoa(quotaUsage.OrgUsage.Services), servicesLimit))
+	table.Add(T("Memory"), fmt.Sprintf("%s/%s", formatters.ByteSize(quotaUsage.OrgUsage.Memory*formatters.MEGABYTE), formatters.ByteSize(quotaUsage.MemoryLimit*formatters.MEGABYTE)))
+	table.Print()
+
+	cmd.ui.Ok()
+}

--- a/cf/commands/organization/org_quota_usage_test.go
+++ b/cf/commands/organization/org_quota_usage_test.go
@@ -1,0 +1,121 @@
+package organization_test
+
+import (
+	test_org "github.com/cloudfoundry/cli/cf/api/organizations/fakes"
+	"github.com/cloudfoundry/cli/cf/commands/organization"
+	"github.com/cloudfoundry/cli/cf/configuration/core_config"
+	"github.com/cloudfoundry/cli/cf/errors"
+	"github.com/cloudfoundry/cli/cf/models"
+	testcmd "github.com/cloudfoundry/cli/testhelpers/commands"
+	testconfig "github.com/cloudfoundry/cli/testhelpers/configuration"
+	testreq "github.com/cloudfoundry/cli/testhelpers/requirements"
+	testterm "github.com/cloudfoundry/cli/testhelpers/terminal"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/cloudfoundry/cli/testhelpers/matchers"
+)
+
+var _ = Describe("org command", func() {
+	var (
+		ui                  *testterm.FakeUI
+		orgRepo             *test_org.FakeOrganizationRepository
+		configRepo          core_config.ReadWriter
+		requirementsFactory *testreq.FakeReqFactory
+		quotaUsage          models.QuotaUsage
+	)
+
+	runCommand := func(args ...string) bool {
+		cmd := organization.NewQuotaUsage(ui, configRepo, orgRepo)
+		return testcmd.RunCommand(cmd, args, requirementsFactory)
+	}
+
+	BeforeEach(func() {
+		ui = &testterm.FakeUI{}
+		configRepo = testconfig.NewRepositoryWithDefaults()
+		orgRepo = &test_org.FakeOrganizationRepository{}
+		requirementsFactory = &testreq.FakeReqFactory{LoginSuccess: true}
+	})
+
+	Describe("requirements", func() {
+		It("fails when not logged in", func() {
+			requirementsFactory.LoginSuccess = false
+
+			Expect(runCommand()).To(BeFalse())
+		})
+		It("should fail with usage when not provided exactly one arg", func() {
+			requirementsFactory.LoginSuccess = true
+			Expect(runCommand("too", "much")).To(BeFalse())
+			Expect(ui.FailedWithUsage).To(BeTrue())
+		})
+
+	})
+
+	Context("when there are quota usage to be listed", func() {
+		BeforeEach(func() {
+			quotaUsage = models.QuotaUsage{}
+			quotaUsage.Name = "Organization-Quota"
+			quotaUsage.MemoryLimit = 10240
+			quotaUsage.RoutesLimit = 1000
+			quotaUsage.ServicesLimit = 100
+			quotaUsage.OrgUsage.Routes = 6
+			quotaUsage.OrgUsage.Services = 6
+			quotaUsage.OrgUsage.Memory = 1280
+
+			org := models.Organization{}
+			org.Name = "my-org"
+			org.Guid = "my-org-guid"
+
+			orgRepo.FindByNameReturns(org, nil)
+		})
+
+		It("lists quota usage", func() {
+			orgRepo.GetOrganizationQuotaUsageReturns(quotaUsage, nil)
+
+			runCommand("my-org")
+
+			Expect(ui.Outputs).To(ContainSubstrings(
+				[]string{"Getting quota usage info for org my-org as my-user"},
+				[]string{"Routes", "6/1000"},
+				[]string{"Services", "6/100"},
+				[]string{"Memory", "1.2G/10G"},
+				[]string{"OK"},
+			))
+		})
+
+		It("lists quota usage when service limit is -1", func() {
+			quotaUsage.ServicesLimit = int(-1)
+			orgRepo.GetOrganizationQuotaUsageReturns(quotaUsage, nil)
+
+			runCommand("my-org")
+
+			Expect(ui.Outputs).To(ContainSubstrings(
+				[]string{"Getting quota usage info for org my-org as my-user"},
+				[]string{"Routes", "6/1000"},
+				[]string{"Services", "6/unlimited"},
+				[]string{"Memory", "1.2G/10G"},
+				[]string{"OK"},
+			))
+		})
+	})
+
+	It("tells the user when org not found", func() {
+		orgRepo.FindByNameReturns(models.Organization{}, errors.New("Organization dummy-org-name not found"))
+		runCommand("dummy-Org-Name")
+
+		Expect(ui.Outputs).To(ContainSubstrings(
+			[]string{"Getting quota usage info for org dummy-Org-Name as my-user"},
+			[]string{"Organization dummy-org-name not found"},
+		))
+	})
+
+	It("tell user error return from endpoint", func() {
+		orgRepo.GetOrganizationQuotaUsageReturns(models.QuotaUsage{}, errors.New("User does not have access"))
+		runCommand("my-org")
+
+		Expect(ui.Outputs).To(ContainSubstrings(
+			[]string{"Getting quota usage info for org my-org as my-user"},
+			[]string{"User does not have access"},
+		))
+	})
+})

--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -5303,5 +5303,30 @@
       "id": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "translation": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "modified": false
+   },
+   {
+      "id": "Getting quota usage info for org {{.OrgName}} as {{.Username}}...",
+      "translation": "Getting quota usage info for org {{.OrgName}} as {{.Username}}...",
+      "modified": false
+   },
+   {
+      "id": "Get quota usage for org",
+      "translation": "Get quota usage for org",
+      "modified": false
+   },
+   {
+      "id": "CF_NAME org-quota-usage ORG_NAME \n\n",
+      "translation": "CF_NAME org-quota-usage ORG_NAME \n\n",
+      "modified": false
+   },
+   {
+      "id": "View all organizations with 'CF_NAME orgs'",
+      "translation": "View all organizations with 'CF_NAME orgs'",
+      "modified": false
+   },
+   {
+      "id": "Memory",
+      "translation": "Memory",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -5303,5 +5303,30 @@
       "id": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "translation": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "modified": false
+   },
+   {
+      "id": "Getting quota usage info for org {{.OrgName}} as {{.Username}}...",
+      "translation": "Getting quota usage info for org {{.OrgName}} as {{.Username}}...",
+      "modified": false
+   },
+   {
+      "id": "Get quota usage for org",
+      "translation": "Get quota usage for org",
+      "modified": false
+   },
+   {
+      "id": "CF_NAME org-quota-usage ORG_NAME \n\n",
+      "translation": "CF_NAME org-quota-usage ORG_NAME \n\n",
+      "modified": false
+   },
+   {
+      "id": "View all organizations with 'CF_NAME orgs'",
+      "translation": "View all organizations with 'CF_NAME orgs'",
+      "modified": false
+   },
+   {
+      "id": "Memory",
+      "translation": "Memory",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -5303,5 +5303,30 @@
       "id": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "translation": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instancias",
       "modified": false
+   },
+   {
+      "id": "Getting quota usage info for org {{.OrgName}} as {{.Username}}...",
+      "translation": "Getting quota usage info for org {{.OrgName}} as {{.Username}}...",
+      "modified": false
+   },
+   {
+      "id": "Get quota usage for org",
+      "translation": "Get quota usage for org",
+      "modified": false
+   },
+   {
+      "id": "CF_NAME org-quota-usage ORG_NAME \n\n",
+      "translation": "CF_NAME org-quota-usage ORG_NAME \n\n",
+      "modified": false
+   },
+   {
+      "id": "View all organizations with 'CF_NAME orgs'",
+      "translation": "View all organizations with 'CF_NAME orgs'",
+      "modified": false
+   },
+   {
+      "id": "Memory",
+      "translation": "Memory",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -5303,5 +5303,30 @@
       "id": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "translation": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "modified": false
+   },
+   {
+      "id": "Getting quota usage info for org {{.OrgName}} as {{.Username}}...",
+      "translation": "Obtenir des informations sur l'utilisation de quotas pour les org {{ }} .OrgName que {{ }} .Username ...",
+      "modified": false
+   },
+   {
+      "id": "Get quota usage for org",
+      "translation": "Obtenez l'utilisation des quotas pour org",
+      "modified": false
+   },
+   {
+      "id": "CF_NAME org-quota-usage ORG_NAME \n\n",
+      "translation": "CF_NAME org-quota-usage ORG_NAME \n\n",
+      "modified": false
+   },
+   {
+      "id": "View all organizations with 'CF_NAME orgs'",
+      "translation": "Voir tous les organismes avec 'CF_NAME orgs'",
+      "modified": false
+   },
+   {
+      "id": "Memory",
+      "translation": "mémoire",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -5303,5 +5303,30 @@
       "id": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "translation": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "modified": false
+   },
+   {
+      "id": "Getting quota usage info for org {{.OrgName}} as {{.Username}}...",
+      "translation": "Getting quota usage info for org {{.OrgName}} as {{.Username}}...",
+      "modified": false
+   },
+   {
+      "id": "Get quota usage for org",
+      "translation": "Get quota usage for org",
+      "modified": false
+   },
+   {
+      "id": "CF_NAME org-quota-usage ORG_NAME \n\n",
+      "translation": "CF_NAME org-quota-usage ORG_NAME \n\n",
+      "modified": false
+   },
+   {
+      "id": "View all organizations with 'CF_NAME orgs'",
+      "translation": "View all organizations with 'CF_NAME orgs'",
+      "modified": false
+   },
+   {
+      "id": "Memory",
+      "translation": "Memory",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -5303,5 +5303,30 @@
       "id": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "translation": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "modified": false
+   },
+   {
+      "id": "Getting quota usage info for org {{.OrgName}} as {{.Username}}...",
+      "translation": "Getting quota usage info for org {{.OrgName}} as {{.Username}}...",
+      "modified": false
+   },
+   {
+      "id": "Get quota usage for org",
+      "translation": "Get quota usage for org",
+      "modified": false
+   },
+   {
+      "id": "CF_NAME org-quota-usage ORG_NAME \n\n",
+      "translation": "CF_NAME org-quota-usage ORG_NAME \n\n",
+      "modified": false
+   },
+   {
+      "id": "View all organizations with 'CF_NAME orgs'",
+      "translation": "View all organizations with 'CF_NAME orgs'",
+      "modified": false
+   },
+   {
+      "id": "Memory",
+      "translation": "Memory",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -5303,5 +5303,30 @@
       "id": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "translation": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instâncias",
       "modified": false
+   },
+   {
+      "id": "Getting quota usage info for org {{.OrgName}} as {{.Username}}...",
+      "translation": "Getting quota usage info for org {{.OrgName}} as {{.Username}}...",
+      "modified": false
+   },
+   {
+      "id": "Get quota usage for org",
+      "translation": "Get quota usage for org",
+      "modified": false
+   },
+   {
+      "id": "CF_NAME org-quota-usage ORG_NAME \n\n",
+      "translation": "CF_NAME org-quota-usage ORG_NAME \n\n",
+      "modified": false
+   },
+   {
+      "id": "View all organizations with 'CF_NAME orgs'",
+      "translation": "View all organizations with 'CF_NAME orgs'",
+      "modified": false
+   },
+   {
+      "id": "Memory",
+      "translation": "Memory",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/zh_Hans.all.json
+++ b/cf/i18n/resources/zh_Hans.all.json
@@ -5303,5 +5303,30 @@
       "id": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "translation": "{{.Usage}} {{.FormattedMemory}} 乘以 {{.InstanceCount}}实例数",
       "modified": false
+   },
+   {
+      "id": "Getting quota usage info for org {{.OrgName}} as {{.Username}}...",
+      "translation": "为获得组织的配额使用信息 {{.OrgName}} as {{.Username}}...",
+      "modified": false
+   },
+   {
+      "id": "Get quota usage for org",
+      "translation": "获取配额使用率组织",
+      "modified": false
+   },
+   {
+      "id": "CF_NAME org-quota-usage ORG_NAME \n\n",
+      "translation": "CF_NAME org-quota-usage ORG_NAME \n\n",
+      "modified": false
+   },
+   {
+      "id": "View all organizations with 'CF_NAME orgs'",
+      "translation": "查看所有机构 'CF_NAME orgs'",
+      "modified": false
+   },
+   {
+      "id": "Memory",
+      "translation": "记忆",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/zh_Hant.all.json
+++ b/cf/i18n/resources/zh_Hant.all.json
@@ -5303,5 +5303,30 @@
       "id": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "translation": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "modified": false
+   },
+   {
+      "id": "Getting quota usage info for org {{.OrgName}} as {{.Username}}...",
+      "translation": "Getting quota usage info for org {{.OrgName}} as {{.Username}}...",
+      "modified": false
+   },
+   {
+      "id": "Get quota usage for org",
+      "translation": "Get quota usage for org",
+      "modified": false
+   },
+   {
+      "id": "CF_NAME org-quota-usage ORG_NAME \n\n",
+      "translation": "CF_NAME org-quota-usage ORG_NAME \n\n",
+      "modified": false
+   },
+   {
+      "id": "View all organizations with 'CF_NAME orgs'",
+      "translation": "View all organizations with 'CF_NAME orgs'",
+      "modified": false
+   },
+   {
+      "id": "Memory",
+      "translation": "Memory",
+      "modified": false
    }
 ]

--- a/cf/models/quota.go
+++ b/cf/models/quota.go
@@ -10,6 +10,17 @@ func NewQuotaFields(name string, memory int64, InstanceMemoryLimit int64, routes
 	return
 }
 
+type OrgUsageFields struct {
+	Routes   int   `json:"routes"`
+	Services int   `json:"services"`
+	Memory   int64 `json:"memory"`
+}
+
+type QuotaUsage struct {
+	QuotaFields
+	OrgUsage OrgUsageFields `json:"org_usage"`
+}
+
 type QuotaFields struct {
 	Guid                    string `json:"guid,omitempty"`
 	Name                    string `json:"name"`


### PR DESCRIPTION
Provide routes, services and memory used by organization.

This is the PR for https://www.pivotaltracker.com/story/show/94171010.
Output : 
```
# cf org-quota-usage serviceQuotaOrg
Getting quota usage info for org serviceQuotaOrg as admin...

Routes     5/5
Services   7/7
Memory    512M/1G
OK
```

Issue: 
http://rnd-github.huawei.com/cloudfoundry/cli/issues/33

