### PR TITLE
Fix create-app-manifest only includes one host [92530254]

### DIFF
--- a/cf/commands/create_app_manifest.go
+++ b/cf/commands/create_app_manifest.go
@@ -133,7 +133,9 @@ func (cmd *CreateAppManifest) createManifest(app models.Application, savePath st
 	}
 
 	if len(app.Routes) > 0 {
-		cmd.manifest.Domain(app.Name, app.Routes[0].Host, app.Routes[0].Domain.Name)
+		for i := 0; i < len(app.Routes); i++ {
+			cmd.manifest.Domain(app.Name, app.Routes[i].Host, app.Routes[i].Domain.Name)
+		}
 	}
 
 	err := cmd.manifest.Save()

--- a/cf/commands/create_app_manifest_test.go
+++ b/cf/commands/create_app_manifest_test.go
@@ -106,7 +106,7 @@ var _ = Describe("create-app-manifest Command", func() {
 				Ω(fakeManifest.EnvironmentVarsCallCount()).To(Equal(1))
 				Ω(fakeManifest.HealthCheckTimeoutCallCount()).To(Equal(1))
 				Ω(fakeManifest.InstancesCallCount()).To(Equal(1))
-				Ω(fakeManifest.DomainCallCount()).To(Equal(1))
+				Ω(fakeManifest.DomainCallCount()).To(Equal(2))
 				Ω(fakeManifest.ServiceCallCount()).To(Equal(1))
 				Ω(fakeManifest.StartCommandCallCount()).To(Equal(1))
 			})

--- a/cf/manifest/generate_manifest.go
+++ b/cf/manifest/generate_manifest.go
@@ -127,11 +127,17 @@ func (m *appManifest) Save() error {
 		}
 
 		if len(app.Routes) > 0 {
-			if _, err := fmt.Fprintf(f, "  host: %s\n", app.Routes[0].Host); err != nil {
-				return err
-			}
-			if _, err := fmt.Fprintf(f, "  domain: %s\n", app.Routes[0].Domain.Name); err != nil {
-				return err
+			if len(app.Routes) == 1 {
+				if _, err := fmt.Fprintf(f, "  host: %s\n", app.Routes[0].Host); err != nil {
+					return err
+				}
+				if _, err := fmt.Fprintf(f, "  domain: %s\n", app.Routes[0].Domain.Name); err != nil {
+					return err
+				}
+			} else {
+				if err := writeRoutesToFile(f, app.Routes); err != nil {
+					return err
+				}
 			}
 		} else {
 			if _, err := fmt.Fprintf(f, "  no-route: true\n"); err != nil {
@@ -173,7 +179,63 @@ func (m *appManifest) addApplication(name string) {
 		},
 	})
 }
+func writeRoutesToFile(f *os.File, routes []models.RouteSummary) error {
+	var (
+		hostSlice    []string
+		domainSlice  []string
+		hostPSlice   *[]string
+		domainPSlice *[]string
+		hosts        []string
+		domains      []string
+	)
 
+	for i := 0; i < len(routes); i++ {
+		hostSlice = append(hostSlice, routes[i].Host)
+		domainSlice = append(domainSlice, routes[i].Domain.Name)
+	}
+
+	hostPSlice = removeDuplicatedValue(hostSlice)
+	domainPSlice = removeDuplicatedValue(domainSlice)
+
+	if hostPSlice != nil {
+		hosts = *hostPSlice
+	}
+	if domainPSlice != nil {
+		domains = *domainPSlice
+	}
+
+	if len(hosts) == 1 {
+		if _, err := fmt.Fprintf(f, "  host: %s\n", hosts[0]); err != nil {
+			return err
+		}
+	} else {
+		if _, err := fmt.Fprintln(f, "  hosts:"); err != nil {
+			return err
+		}
+		for i := 0; i < len(hosts); i++ {
+			if _, err := fmt.Fprintf(f, "  - %s\n", hosts[i]); err != nil {
+				return err
+			}
+		}
+	}
+
+	if len(domains) == 1 {
+		if _, err := fmt.Fprintf(f, "  domain: %s\n", domains[0]); err != nil {
+			return err
+		}
+	} else {
+		if _, err := fmt.Fprintln(f, "  domains:"); err != nil {
+			return err
+		}
+		for i := 0; i < len(domains); i++ {
+			if _, err := fmt.Fprintf(f, "  - %s\n", domains[i]); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
 func writeServicesToFile(f *os.File, entries []models.ServicePlanSummary) error {
 	_, err := fmt.Fprintln(f, "  services:")
 	if err != nil {

--- a/cf/manifest/generate_manifest_test.go
+++ b/cf/manifest/generate_manifest_test.go
@@ -112,6 +112,111 @@ var _ = Describe("generate_manifest", func() {
 			[]string{"  buildpack: ruby-buildpack"},
 		))
 	})
+	Context("When there are multiple hosts and domains", func() {
+
+		It("generates a manifest containing two hosts two domains", func() {
+			m.Memory("app1", 128)
+			m.StartCommand("app1", "run main.go")
+			m.Service("app1", "service1")
+			m.EnvironmentVars("app1", "foo", "boo")
+			m.HealthCheckTimeout("app1", 100)
+			m.Instances("app1", 3)
+			m.Domain("app1", "foo1", "test1.com")
+			m.Domain("app1", "foo1", "test2.com")
+			m.Domain("app1", "foo2", "test1.com")
+			m.Domain("app1", "foo2", "test2.com")
+			m.BuildpackUrl("app1", "ruby-buildpack")
+			err := m.Save()
+			Ω(err).NotTo(HaveOccurred())
+
+			Ω(getYamlContent("./output.yml")).To(ContainSubstrings(
+				[]string{"- name: app1"},
+				[]string{"  memory: 128M"},
+				[]string{"  command: run main.go"},
+				[]string{"  services:"},
+				[]string{"  - service1"},
+				[]string{"  env:"},
+				[]string{"    foo: boo"},
+				[]string{"  timeout: 100"},
+				[]string{"  instances: 3"},
+				[]string{"  hosts:"},
+				[]string{"  - foo1"},
+				[]string{"  - foo2"},
+				[]string{"  domains:"},
+				[]string{"  - test1.com"},
+				[]string{"  - test2.com"},
+				[]string{"  buildpack: ruby-buildpack"},
+			))
+		})
+	})
+
+	Context("When there are multiple hosts and single domain", func() {
+
+		It("generates a manifest containing two hosts one domain", func() {
+			m.Memory("app1", 128)
+			m.StartCommand("app1", "run main.go")
+			m.Service("app1", "service1")
+			m.EnvironmentVars("app1", "foo", "boo")
+			m.HealthCheckTimeout("app1", 100)
+			m.Instances("app1", 3)
+			m.Domain("app1", "foo1", "test.com")
+			m.Domain("app1", "foo2", "test.com")
+			m.BuildpackUrl("app1", "ruby-buildpack")
+			err := m.Save()
+			Ω(err).NotTo(HaveOccurred())
+
+			Ω(getYamlContent("./output.yml")).To(ContainSubstrings(
+				[]string{"- name: app1"},
+				[]string{"  memory: 128M"},
+				[]string{"  command: run main.go"},
+				[]string{"  services:"},
+				[]string{"  - service1"},
+				[]string{"  env:"},
+				[]string{"    foo: boo"},
+				[]string{"  timeout: 100"},
+				[]string{"  instances: 3"},
+				[]string{"  hosts:"},
+				[]string{"  - foo1"},
+				[]string{"  - foo2"},
+				[]string{"  domain: test.com"},
+				[]string{"  buildpack: ruby-buildpack"},
+			))
+		})
+	})
+
+	Context("When there is single host and multiple domains", func() {
+
+		It("generates a manifest containing one host two domains", func() {
+			m.Memory("app1", 128)
+			m.StartCommand("app1", "run main.go")
+			m.Service("app1", "service1")
+			m.EnvironmentVars("app1", "foo", "boo")
+			m.HealthCheckTimeout("app1", 100)
+			m.Instances("app1", 3)
+			m.Domain("app1", "foo", "test1.com")
+			m.Domain("app1", "foo", "test2.com")
+			m.BuildpackUrl("app1", "ruby-buildpack")
+			err := m.Save()
+			Ω(err).NotTo(HaveOccurred())
+
+			Ω(getYamlContent("./output.yml")).To(ContainSubstrings(
+				[]string{"- name: app1"},
+				[]string{"  memory: 128M"},
+				[]string{"  command: run main.go"},
+				[]string{"  services:"},
+				[]string{"  - service1"},
+				[]string{"  env:"},
+				[]string{"    foo: boo"},
+				[]string{"  timeout: 100"},
+				[]string{"  instances: 3"},
+				[]string{"  host: foo"},
+				[]string{"  domains:"},
+				[]string{"  - test1.com"},
+				[]string{"  - test2.com"},
+				[]string{"  buildpack: ruby-buildpack"},
+			))
+		})
+	})
 
 })
 


### PR DESCRIPTION
After fixing the issue cli create-app-manifest will cosiders
hosts,domains based on multiple routes to an app,so when ever
has more then one host or domain uses the hosts & domains
key word  respectively.
the changed code doesn't have perf impact if an app has single route
